### PR TITLE
fix: Update camera visual definition dimensions

### DIFF
--- a/src/tractor_bringup/urdf/tractor.urdf.xacro
+++ b/src/tractor_bringup/urdf/tractor.urdf.xacro
@@ -134,14 +134,14 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
-        <box size="0.09 0.025 0.025"/> <!-- Updated dimensions -->
+        <box size="0.025 0.09 0.025"/> <!-- Updated dimensions -->
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
-        <box size="0.09 0.025 0.025"/> <!-- Updated dimensions -->
+        <box size="0.025 0.09 0.025"/> <!-- Updated dimensions -->
       </geometry>
     </collision>
     <inertial>


### PR DESCRIPTION
The camera's visual and collision model dimensions have been updated to represent the 90mm side along its Y-axis as per user request. The original dimensions were 0.09m (X), 0.025m (Y), 0.025m (Z). The new dimensions are 0.025m (X), 0.09m (Y), 0.025m (Z).