### PR TITLE
Fix: Update encoder_ppr to 1980 for 45:1 motors

### DIFF
--- a/simple_start.sh
+++ b/simple_start.sh
@@ -171,7 +171,7 @@ main() {
         -p motor_controller_address:=0x34 \
         -p use_pwm_control:=false \
         -p motor_type:=3 \
-        -p encoder_ppr:=135 \
+        -p encoder_ppr:=1980 \
         -p publish_rate:=5.0 \
         -p max_motor_speed:=50 \
         -p wheel_separation:=0.5 \


### PR DESCRIPTION
The previous encoder_ppr value of 135 was incorrect for the motors with a 45:1 gear ratio, assuming a common base motor encoder PPR of 44. This change updates encoder_ppr to 1980 (44 * 45) in simple_start.sh.

This is crucial for the Hiwonder controller's internal closed-loop speed control (when use_pwm_control=false) to accurately interpret motor rotation and regulate speed effectively.