### PR TITLE
Feat: Configure system for velocity_feedback_controller drift correction

### DIFF
--- a/src/tractor_bringup/config/hiwonder_motor_params.yaml
+++ b/src/tractor_bringup/config/hiwonder_motor_params.yaml
@@ -8,7 +8,7 @@ hiwonder_motor_driver:
     deadband: 0.05
     encoder_ppr: 1980
     publish_rate: 100.0 # Note: Driver comments suggest sensor data published at 100Hz timer, not via this param.
-    use_pwm_control: True
+    use_pwm_control: False # Changed to False for closed-loop speed control by Hiwonder board
     motor_type: 3
     min_samples_for_estimation: 10
     max_history_minutes: 60

--- a/src/tractor_control/tractor_control/hiwonder_motor_driver.py
+++ b/src/tractor_control/tractor_control/hiwonder_motor_driver.py
@@ -475,8 +475,14 @@ class HiwonderMotorDriver(Node):
             "left_viz_wheel_joint",
             "right_viz_wheel_joint",
         ]
-        # Fixed tracks + rotating viz wheels
-        joint_msg.position = [0.0, 0.0, left_wheel_pos, right_wheel_pos]
+        # Publish raw encoder counts for left_wheel_joint and right_wheel_joint
+        # and scaled radians for visualization wheels.
+        joint_msg.position = [
+            float(left_encoder),
+            float(right_encoder),
+            left_wheel_pos,
+            right_wheel_pos,
+        ]
         # Fixed tracks + wheel velocities
         joint_msg.velocity = [0.0, 0.0, self.left_velocity, self.right_velocity]
 


### PR DESCRIPTION
This commit makes the necessary changes to enable and utilize the drift correction mechanism within `velocity_feedback_controller.py`.

Changes include:
1. `hiwonder_motor_driver.py`: Modified to publish raw encoder counts in `/joint_states` (for `left_wheel_joint` and `right_wheel_joint` positions). This provides the data needed by the feedback controller's drift correction logic.
2. `hiwonder_motor_params.yaml`: Set `use_pwm_control` to `False`. This enables the Hiwonder motor controller's internal closed-loop speed control, which is essential for the `velocity_feedback_controller` to effectively manage target speeds and apply corrections based on odometry. `encoder_ppr` was already correctly set to 1980.

To use this, the system should be launched with
`control_with_feedback.launch.py`, which runs both the hiwonder driver and the velocity feedback controller. The `drift_correction_gain` parameter in `velocity_feedback_controller` (set via the launch file) can then be tuned to minimize persistent drift.