### PR TITLE
Fix: Add missing launch files to setup.py installation

### DIFF
--- a/src/tractor_bringup/setup.py
+++ b/src/tractor_bringup/setup.py
@@ -21,6 +21,8 @@ setup(
         ("share/" + package_name + "/launch", ["launch/hiwonder_control.launch.py"]),
         ("share/" + package_name + "/launch", ["launch/robot_localization.launch.py"]),
         ("share/" + package_name + "/launch", ["launch/slam_mapping.launch.py"]),
+        ("share/" + package_name + "/launch", ["launch/control_with_feedback.launch.py"]), # Added this line
+        ("share/" + package_name + "/launch", ["launch/xbox_teleop_with_feedback.launch.py"]), # Added this line
         ("share/" + package_name + "/urdf", ["urdf/tractor.urdf.xacro"]),
         ("share/" + package_name + "/config", ["config/nav2_params.yaml"]),
         ("share/" + package_name + "/config", ["config/robot_localization.yaml"]),


### PR DESCRIPTION
`control_with_feedback.launch.py` and
`xbox_teleop_with_feedback.launch.py` were missing from the `data_files` in `src/tractor_bringup/setup.py`.

This prevented `ros2 launch` from finding these files, causing an error when trying to run scripts that depended on them.

This commit adds the necessary entries to `setup.py` to ensure these launch files are installed to the package's share directory.