### PR TITLE
feat: Tune reward system to discourage spinning

### DIFF
--- a/src/tractor_bringup/tractor_bringup/improved_reward_system.py
+++ b/src/tractor_bringup/tractor_bringup/improved_reward_system.py
@@ -42,10 +42,10 @@ class ImprovedRewardCalculator:
             'speed_bonus_multiplier': 3.0,
             
             # Straight-line movement rewards
-            'straight_line_bonus': 8.0,  # Strong reward for going straight
-            'forward_progress_multiplier': 25.0,  # Heavy emphasis on forward movement
+            'straight_line_bonus': 12.0,  # Strong reward for going straight
+            'forward_progress_multiplier': 40.0,  # Heavy emphasis on forward movement
             'angular_penalty_threshold': 0.3,  # rad/s threshold for penalizing turning
-            'excessive_turning_penalty': -4.0,  # Penalty for too much turning
+            'excessive_turning_penalty': -10.0,  # Penalty for too much turning
             
             # Wall following and frontier exploration
             'wall_following_bonus': 5.0,  # Reward for maintaining distance from walls
@@ -73,8 +73,8 @@ class ImprovedRewardCalculator:
             
             # Differential drive tracking
             'track_efficiency_bonus': 4.0,      # Reward for efficient differential drive
-            'wheel_slip_penalty': -2.0,         # Penalty for wheel slippage
-            'coordinated_turning_bonus': 3.0,   # Reward for proper tank steering
+            'wheel_slip_penalty': -4.0,         # Penalty for wheel slippage
+            'coordinated_turning_bonus': 5.0,   # Reward for proper tank steering
         }
     
     def calculate_comprehensive_reward(self, 


### PR DESCRIPTION
The rover was exhibiting a tendency to spin in place rather than explore. This was likely due to the reward function not sufficiently penalizing this behavior.

This commit adjusts the reward parameters in `improved_reward_system.py` to make forward exploration more favorable:

- Increases the penalty for excessive turning.
- Increases the rewards for straight-line movement and forward progress.
- Increases the penalty for wheel slip and rewards for coordinated wheel movement.

These changes create a stronger incentive for the model to learn to drive forward and should reduce the spinning behavior.